### PR TITLE
minor bug fixes to grid_opt.py

### DIFF
--- a/pyschism/grid_opt.py
+++ b/pyschism/grid_opt.py
@@ -820,7 +820,7 @@ def init_logger():
 def grid_opt_with_args(args):
     """ Optimize grid with arguments parsed by argparse
     """
-    with open(args.optparam) as f:
+    with open(args.optparm) as f:
         opt_param = schism_yaml.load(f)
     mesh = read_mesh(args.filename, nodestring_option='land')
     with open(args.demfile, 'r') as f:
@@ -844,6 +844,7 @@ def main():
     parser = create_arg_parser()
     args = parser.parse_args()
     grid_opt_with_args(args)
+    args.na_fill = -999999
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
args.optparm is created , but then used as args.optparam, so I changed it to args.optparm
args.na_fill is never defined. I added a line to provide a default value for na_fill. Probably needs to be a command line argument with a default value, but this at least allows the code to run.